### PR TITLE
Show guest details on iPhone dashboard

### DIFF
--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -740,10 +740,12 @@ export default function SortableGuestTable() {
                           {getFirstInitial(guest.name)}
                         </div>
                         <div>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline" className="bg-blue-600 text-white border-blue-600">{guest.capsuleNumber}</Badge>
-                            <span className="font-medium">{guest.name}</span>
-                          </div>
+                                                <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="bg-blue-600 text-white border-blue-600">{guest.capsuleNumber}</Badge>
+                        <button onClick={() => handleGuestClick(guest)} className="font-medium hover:underline focus:outline-none">
+                          {guest.name}
+                        </button>
+                      </div>
                           <div className="text-xs text-gray-600 mt-1">
                             In: {formatShortDateTime(guest.checkinTime.toString())}
                             {guest.expectedCheckoutDate && (
@@ -756,7 +758,7 @@ export default function SortableGuestTable() {
                         <Button 
                           variant="ghost" 
                           className="h-11 w-11 rounded-full"
-                          onClick={() => setSelectedGuest(guest)}
+                          onClick={() => handleGuestClick(guest)}
                           title="Details"
                         >
                           i


### PR DESCRIPTION
Enable tapping guest name and 'i' button on mobile to display guest details, matching desktop behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-7058d8fc-5102-483f-a8c4-fa8b5119a9da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7058d8fc-5102-483f-a8c4-fa8b5119a9da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

