### PR TITLE
Shorten create guest link button text

### DIFF
--- a/client/src/components/guest-token-generator.tsx
+++ b/client/src/components/guest-token-generator.tsx
@@ -177,7 +177,7 @@ export default function GuestTokenGenerator({ onTokenCreated }: TokenGeneratorPr
         <DialogTrigger asChild>
           <Button variant="outline" size="sm" className="flex items-center gap-2">
             <Link2 className="h-4 w-4" />
-            Create Guest Link
+            Create Link
           </Button>
         </DialogTrigger>
       <DialogContent className="w-full max-w-sm sm:max-w-md mx-4">


### PR DESCRIPTION
Shorten 'Create Guest Link' to 'Create Link' to improve mobile interface readability on the Guest Check-in page.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecacf49a-6e42-4ef0-b487-d8adffdbc3d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecacf49a-6e42-4ef0-b487-d8adffdbc3d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

