### PR TITLE
Fix accommodation term persistence and system-wide application

### DIFF
--- a/__tests__/super-simple.test.js
+++ b/__tests__/super-simple.test.js
@@ -1,4 +1,5 @@
 // Super simple test that should definitely pass
+
 test('basic math', () => {
   expect(1 + 1).toBe(2);
 });

--- a/client/src/components/capsule-cleaning-status.tsx
+++ b/client/src/components/capsule-cleaning-status.tsx
@@ -40,7 +40,7 @@ function MarkCleanedDialog({ capsule, onSuccess }: MarkCleanedDialogProps) {
     onSuccess: () => {
       toast({
         title: "Success",
-        description: `Capsule ${capsule.number} marked as cleaned successfully`,
+        description: `${labels.singular} ${capsule.number} marked as cleaned successfully`,
       });
       setOpen(false);
       onSuccess();
@@ -72,7 +72,7 @@ function MarkCleanedDialog({ capsule, onSuccess }: MarkCleanedDialogProps) {
         <DialogHeader>
           <DialogTitle>Mark {labels.singular} {capsule.number} as Cleaned</DialogTitle>
           <DialogDescription>
-            Are you sure you want to mark this capsule as cleaned?
+            Are you sure you want to mark this {labels.lowerSingular} as cleaned?
           </DialogDescription>
         </DialogHeader>
         <div className="py-4">

--- a/client/src/components/guest-details-modal.tsx
+++ b/client/src/components/guest-details-modal.tsx
@@ -12,6 +12,7 @@ import { User, Calendar, MapPin, Phone, Mail, CreditCard, Edit, Save, X } from "
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { Guest } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 interface GuestDetailsModalProps {
   guest: Guest | null;
@@ -20,6 +21,7 @@ interface GuestDetailsModalProps {
 }
 
 export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetailsModalProps) {
+  const labels = useAccommodationLabels();
   const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<Partial<Guest>>({});
   const { toast } = useToast();
@@ -333,7 +335,7 @@ export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetai
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <Label>Capsule</Label>
+                <Label>{labels.singular}</Label>
                 <div className="mt-1">
                   <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-200">
                     <MapPin className="h-3 w-3 mr-1" />

--- a/client/src/components/guest-table.tsx
+++ b/client/src/components/guest-table.tsx
@@ -7,6 +7,7 @@ import { UserMinus } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { Guest } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 function formatDuration(checkinTime: string): string {
   const checkin = new Date(checkinTime);
@@ -24,6 +25,7 @@ function getInitials(name: string): string {
 }
 
 export default function GuestTable() {
+  const labels = useAccommodationLabels();
   const queryClient = useQueryClient();
   const { toast } = useToast();
   
@@ -113,7 +115,7 @@ export default function GuestTable() {
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Guest Name</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Capsule</th>
+                                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{labels.singular}</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-in Time</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Payment</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>

--- a/client/src/components/guest-token-generator.tsx
+++ b/client/src/components/guest-token-generator.tsx
@@ -11,12 +11,14 @@ import { Link2, Copy, Clock, MapPin, Users } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { Capsule } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 interface TokenGeneratorProps {
   onTokenCreated?: () => void;
 }
 
 export default function GuestTokenGenerator({ onTokenCreated }: TokenGeneratorProps) {
+  const labels = useAccommodationLabels();
   const [selectedCapsule, setSelectedCapsule] = useState("auto-assign");
   const [guestName, setGuestName] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
@@ -243,11 +245,11 @@ export default function GuestTokenGenerator({ onTokenCreated }: TokenGeneratorPr
             <div>
               <Label htmlFor="capsule" className="flex items-center gap-2">
                 <MapPin className="h-4 w-4" />
-                Select Capsule
+                Select {labels.singular}
               </Label>
               <Select value={selectedCapsule} onValueChange={setSelectedCapsule}>
                 <SelectTrigger className="w-full mt-1">
-                  <SelectValue placeholder="Choose capsule assignment" />
+                  <SelectValue placeholder={`Choose ${labels.lowerSingular} assignment`} />
                 </SelectTrigger>
                 <SelectContent>
                   {capsulesLoading ? (

--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -14,6 +14,7 @@ import GuestDetailsModal from "./guest-details-modal";
 import { CheckoutConfirmationDialog } from "./confirmation-dialog";
 import type { Guest, GuestToken, PaginatedResponse } from "@shared/schema";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 type SortField = 'name' | 'capsuleNumber' | 'checkinTime' | 'expectedCheckoutDate';
 type SortOrder = 'asc' | 'desc';
@@ -232,6 +233,7 @@ function SwipeableGuestRow({ guest, onCheckout, onGuestClick, isCondensedView, c
 }
 
 export default function SortableGuestTable() {
+  const labels = useAccommodationLabels();
   const queryClient = useQueryClient();
   const [isCondensedView, setIsCondensedView] = useState(false);
   const [selectedGuest, setSelectedGuest] = useState<Guest | null>(null);
@@ -530,7 +532,7 @@ export default function SortableGuestTable() {
                 <tr>
                   <th className="px-2 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 bg-gray-50 z-10">
                     <div className="flex items-center gap-1">
-                      Capsule
+                      {labels.singular}
                       <SortButton field="capsuleNumber" currentSort={sortConfig} onSort={handleSort} />
                     </div>
                   </th>

--- a/client/src/hooks/useAccommodationLabels.ts
+++ b/client/src/hooks/useAccommodationLabels.ts
@@ -16,6 +16,9 @@ function computeLabels(type: AccommodationType | undefined) {
     lowerPlural,
     numberLabel: `${singular} Number`,
     maintenanceTitle: `${singular} Maintenance`,
+    activeProblemsTitle: `Active Problems`,
+    resolvedProblemsTitle: `Recently Resolved`,
+    noActiveProblems: `No active problems reported. All ${lowerPlural} are in good condition!`,
   };
 }
 

--- a/client/src/pages/check-in.tsx
+++ b/client/src/pages/check-in.tsx
@@ -808,7 +808,7 @@ export default function CheckIn() {
               <li>• Auto-incrementing guest names (Guest1, Guest2...)</li>
               <li>• Gender-based {labels.lowerSingular} assignment (Front for males, Back for females)</li>
               <li>• Quick payment presets: RM45, RM48, RM650 (Monthly)</li>
-              <li>• Admin form: Only name, capsule & payment required</li>
+              <li>• Admin form: Only name, {labels.lowerSingular} & payment required</li>
             </ul>
           </div>
         </CardContent>

--- a/client/src/pages/check-out.tsx
+++ b/client/src/pages/check-out.tsx
@@ -7,6 +7,7 @@ import { UserMinus } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { Guest, PaginatedResponse } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 function formatDuration(checkinTime: string): string {
   const checkin = new Date(checkinTime);
@@ -41,6 +42,7 @@ function getInitials(name: string): string {
 }
 
 export default function CheckOut() {
+  const labels = useAccommodationLabels();
   const queryClient = useQueryClient();
   const { toast } = useToast();
   
@@ -117,7 +119,7 @@ export default function CheckOut() {
                   <thead className="bg-gray-50">
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Guest</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Capsule</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{labels.singular}</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-in Time</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>

--- a/client/src/pages/guest-checkin.tsx
+++ b/client/src/pages/guest-checkin.tsx
@@ -562,11 +562,11 @@ Welcome to Pelangi Capsule Hostel! Here is your check-in slip:
 🏨 PELANGI CAPSULE HOSTEL - CHECK-IN SLIP
 
 Guest Name: ${form.getValues("nameAsInDocument") || guestInfo?.guestName || 'Guest'}
-Capsule Number: ${guestInfo?.capsuleNumber || 'Assigned based on availability'}
+${t.capsuleNumberLabel}: ${guestInfo?.capsuleNumber || 'Assigned based on availability'}
 Check-in: ${checkinTime}
 Check-out: ${checkoutTime}
 Door Password: ${doorPassword}
-Capsule Access Card: Placed on your pillow
+${t.accessCard}: Placed on your pillow
 
 ⚠️ IMPORTANT REMINDERS:
 ${importantReminders}

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Search } from "lucide-react";
 import type { Guest, PaginatedResponse, Capsule } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 function formatDuration(checkinTime: string, checkoutTime: string): string {
   const checkin = new Date(checkinTime);
@@ -26,6 +27,7 @@ function getInitials(name: string): string {
 }
 
 export default function History() {
+  const labels = useAccommodationLabels();
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [searchQuery, setSearchQuery] = useState("");
@@ -190,7 +192,7 @@ export default function History() {
                 <thead className="bg-gray-50">
                   <tr>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Guest Name</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Capsule</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{labels.singular}</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-in</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Check-out</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
@@ -282,7 +284,7 @@ export default function History() {
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-2 sm:space-y-0">
           <div>
             <CardTitle className="text-lg font-semibold text-hostel-text">Cleaning History</CardTitle>
-            <p className="text-sm text-gray-600">Recently cleaned capsules with timestamps</p>
+            <p className="text-sm text-gray-600">Recently cleaned {labels.lowerPlural} with timestamps</p>
           </div>
         </div>
       </CardHeader>

--- a/client/src/pages/maintenance-manage.tsx
+++ b/client/src/pages/maintenance-manage.tsx
@@ -14,8 +14,10 @@ import { useToast } from "@/hooks/use-toast";
 import { AuthContext } from "@/lib/auth";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import type { Capsule, CapsuleProblem, PaginatedResponse } from "@shared/schema";
+import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 
 export default function MaintenanceManage() {
+  const labels = useAccommodationLabels();
   const [selectedCapsule, setSelectedCapsule] = useState<string>("");
   const [problemDescription, setProblemDescription] = useState("");
   const [resolutionNotes, setResolutionNotes] = useState("");
@@ -177,10 +179,10 @@ export default function MaintenanceManage() {
           </CardHeader>
           <CardContent className="space-y-3 sm:space-y-4 p-4 sm:p-6">
             <div>
-              <Label htmlFor="capsule">Select Capsule</Label>
+              <Label htmlFor="capsule">Select {labels.singular}</Label>
               <Select value={selectedCapsule} onValueChange={setSelectedCapsule}>
                 <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Choose a capsule" />
+                  <SelectValue placeholder={`Choose a ${labels.lowerSingular}`} />
                 </SelectTrigger>
                 <SelectContent>
                   {availableCapsules.map((capsule) => (

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1482,7 +1482,7 @@ function MaintenanceTab({ problems, capsules, isLoading, queryClient, toast }: a
           <div className="flex items-center justify-between">
             <CardTitle className="flex items-center gap-2">
               <Wrench className="h-5 w-5 text-orange-600" />
-              Capsule Maintenance
+              {labels.maintenanceTitle}
             </CardTitle>
             <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
               <DialogTrigger asChild>
@@ -1493,20 +1493,20 @@ function MaintenanceTab({ problems, capsules, isLoading, queryClient, toast }: a
               </DialogTrigger>
               <DialogContent>
                 <DialogHeader>
-                  <DialogTitle>Report Capsule Problem</DialogTitle>
+                  <DialogTitle>Report {labels.singular} Problem</DialogTitle>
                 </DialogHeader>
                 <form
                   onSubmit={createProblemForm.handleSubmit((data) => createProblemMutation.mutate(data))}
                   className="space-y-4"
                 >
                   <div>
-                    <Label htmlFor="capsuleNumber">Capsule Number</Label>
+                    <Label htmlFor="capsuleNumber">{labels.numberLabel}</Label>
                     <Select
                       value={createProblemForm.watch("capsuleNumber")}
                       onValueChange={(value) => createProblemForm.setValue("capsuleNumber", value)}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Select capsule" />
+                        <SelectValue placeholder={`Select ${labels.lowerSingular}`} />
                       </SelectTrigger>
                       <SelectContent>
                         {Array.isArray(capsules) && capsules.map((capsule) => (
@@ -1549,11 +1549,11 @@ function MaintenanceTab({ problems, capsules, isLoading, queryClient, toast }: a
           <div className="space-y-6">
             {/* Active Problems */}
             <div>
-              <h3 className="text-lg font-semibold text-red-600 mb-4">Active Problems ({activeProblem.length})</h3>
+              <h3 className="text-lg font-semibold text-red-600 mb-4">{labels.activeProblemsTitle} ({activeProblem.length})</h3>
               {activeProblem.length === 0 ? (
                 <div className="text-center py-8 text-gray-500">
                   <Wrench className="h-12 w-12 mx-auto mb-3 text-gray-300" />
-                  <p>No active problems reported. All capsules are in good condition!</p>
+                  <p>{labels.noActiveProblems}</p>
                 </div>
               ) : (
                 concise ? (
@@ -1561,7 +1561,7 @@ function MaintenanceTab({ problems, capsules, isLoading, queryClient, toast }: a
                     <table className="w-full text-sm">
                       <thead className="bg-red-50">
                         <tr>
-                          <th className="px-4 py-2 text-left">Capsule</th>
+                          <th className="px-4 py-2 text-left">{labels.singular}</th>
                           <th className="px-4 py-2 text-left">Description</th>
                           <th className="px-4 py-2 text-left">Reported By</th>
                           <th className="px-4 py-2 text-left">Date</th>
@@ -1633,7 +1633,7 @@ function MaintenanceTab({ problems, capsules, isLoading, queryClient, toast }: a
             {/* Resolved Problems */}
             {resolvedProblems.length > 0 && (
               <div>
-                <h3 className="text-lg font-semibold text-green-600 mb-4">Recently Resolved ({resolvedProblems.length})</h3>
+                <h3 className="text-lg font-semibold text-green-600 mb-4">{labels.resolvedProblemsTitle} ({resolvedProblems.length})</h3>
                 <div className="grid gap-4 md:grid-cols-2">
                   {resolvedProblems.slice(0, 4).map((problem: CapsuleProblem) => (
                     <Card key={problem.id} className="border-green-200 bg-green-50">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -895,7 +895,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/settings", authenticateToken, async (req, res) => {
     try {
       const guestTokenExpirationHours = await storage.getGuestTokenExpirationHours();
-      const accommodationType = await storage.getSetting('accommodationType') || 'capsule';
+      const accTypeSetting = await storage.getSetting('accommodationType');
+      const accommodationType = accTypeSetting?.value || 'capsule';
       // Load guide fields (fallback empty strings)
       const getVal = async (k: string) => (await storage.getSetting(k))?.value || "";
       res.json({


### PR DESCRIPTION
Fixes accommodation term setting not persisting and dynamically updates 'Capsule' labels across the UI.

The previous implementation of the `/api/settings` endpoint returned the entire setting object for `accommodationType`, causing the UI to revert to the default 'Capsule' instead of the selected term. This PR corrects the API response and replaces hardcoded 'Capsule' strings with dynamic labels to ensure the chosen accommodation term (e.g., 'Room', 'House') is consistently displayed throughout the application, supporting future expansion to other accommodation types like homestays and hotels.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fd4b460-26b9-4598-8a86-c46934e90b3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fd4b460-26b9-4598-8a86-c46934e90b3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

