### PR TITLE
Set capsules to table view by default

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1570,7 +1570,7 @@ function CapsulesTab({ capsules, queryClient, toast, labels }: any) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedCapsule, setSelectedCapsule] = useState<any>(null);
   const [problemsByCapsule, setProblemsByCapsule] = useState<Record<string, any[]>>({});
-  const [viewMode, setViewMode] = useState<'grid' | 'list' | 'table'>('grid');
+  const [viewMode, setViewMode] = useState<'grid' | 'list' | 'table'>('table');
 
   const items = Array.isArray(capsules) ? capsules : [];
 


### PR DESCRIPTION
Set the default view for Settings > Capsules to table view.

---
<a href="https://cursor.com/background-agent?bcId=bc-df766f26-8071-4a5b-bda6-f015074b606a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df766f26-8071-4a5b-bda6-f015074b606a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

