### PR TITLE
refactor: lazy load dashboard widgets

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,17 +1,82 @@
-import SortableGuestTable from "@/components/sortable-guest-table";
-import DailyNotifications from "@/components/daily-notifications";
-import AdminNotifications from "@/components/admin-notifications";
-import OccupancyCalendar from "@/components/occupancy-calendar";
+import React, { Suspense, useEffect, useRef, useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SortableGuestTable = React.lazy(
+  () => import("@/components/sortable-guest-table")
+);
+const DailyNotifications = React.lazy(
+  () => import("@/components/daily-notifications")
+);
+const AdminNotifications = React.lazy(
+  () => import("@/components/admin-notifications")
+);
+const OccupancyCalendar = React.lazy(
+  () => import("@/components/occupancy-calendar")
+);
+
+function useLazyRender<T extends Element>() {
+  const ref = useRef<T | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, visible } as const;
+}
 
 export default function Dashboard() {
+  const table = useLazyRender<HTMLDivElement>();
+  const daily = useLazyRender<HTMLDivElement>();
+  const admin = useLazyRender<HTMLDivElement>();
+  const calendar = useLazyRender<HTMLDivElement>();
+
   return (
     <div className="space-y-6">
-      <SortableGuestTable />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <DailyNotifications />
-        <AdminNotifications />
+      <div ref={table.ref}>
+        {table.visible && (
+          <Suspense fallback={<Skeleton className="h-40 w-full" />}>
+            <SortableGuestTable />
+          </Suspense>
+        )}
       </div>
-      <OccupancyCalendar />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div ref={daily.ref}>
+          {daily.visible && (
+            <Suspense fallback={<Skeleton className="h-40 w-full" />}>
+              <DailyNotifications />
+            </Suspense>
+          )}
+        </div>
+        <div ref={admin.ref}>
+          {admin.visible && (
+            <Suspense fallback={<Skeleton className="h-40 w-full" />}>
+              <AdminNotifications />
+            </Suspense>
+          )}
+        </div>
+      </div>
+      <div ref={calendar.ref}>
+        {calendar.visible && (
+          <Suspense fallback={<Skeleton className="h-80 w-full" />}>
+            <OccupancyCalendar />
+          </Suspense>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- lazy load dashboard widgets with React.lazy and suspense
- mount dashboard widgets on demand using Intersection Observer

## Testing
- `npm test` *(fails: Test suite failed to run in __tests__/super-simple.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_689ca927fbf88329a3f166c0a421ac64