### PR TITLE
feat: lazy-load month holidays in occupancy calendar

### DIFF
--- a/client/src/lib/holidays.ts
+++ b/client/src/lib/holidays.ts
@@ -50,3 +50,39 @@ export function getHolidayLabel(dateStr?: string): string | null {
   const others = matches.filter((h) => h !== primary).map((h) => h.name);
   return `${primary.name}${others.length ? ` (+${others.length} more)` : ""}`;
 }
+
+export type MonthHolidays = {
+  date: string;
+  holidays: Holiday[];
+};
+
+const monthHolidayCache = new Map<string, MonthHolidays[]>();
+
+export async function getMonthHolidays(
+  year: number,
+  month: number,
+): Promise<MonthHolidays[]> {
+  const key = `${year}-${month}`;
+  if (monthHolidayCache.has(key)) {
+    return monthHolidayCache.get(key)!;
+  }
+
+  const grouped: Record<string, Holiday[]> = {};
+  for (const holiday of HOLIDAYS_2025) {
+    const date = new Date(holiday.date);
+    if (date.getFullYear() === year && date.getMonth() === month) {
+      if (!grouped[holiday.date]) {
+        grouped[holiday.date] = [];
+      }
+      grouped[holiday.date].push(holiday);
+    }
+  }
+
+  const result = Object.entries(grouped).map(([date, holidays]) => ({
+    date,
+    holidays,
+  }));
+
+  monthHolidayCache.set(key, result);
+  return result;
+}


### PR DESCRIPTION
## Summary
- lazy-load month holiday list when calendar becomes visible
- compute and cache month holiday data in a utility

## Testing
- `npm test` *(fails: Cannot find name 'test' in __tests__/super-simple.test.ts)*
- `npm run check` *(fails: client/src/pages/settings_backup_broken.tsx: error TS1128: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_689ca97374d08329adceae277a6fc407