### PR TITLE
Require login for occupancy calendar

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,8 +2,11 @@ import SortableGuestTable from "@/components/sortable-guest-table";
 import DailyNotifications from "@/components/daily-notifications";
 import AdminNotifications from "@/components/admin-notifications";
 import OccupancyCalendar from "@/components/occupancy-calendar";
+import { useAuth } from "@/components/auth-provider";
 
 export default function Dashboard() {
+  const { isAuthenticated } = useAuth();
+
   return (
     <div className="space-y-6">
       <SortableGuestTable />
@@ -11,7 +14,7 @@ export default function Dashboard() {
         <DailyNotifications />
         <AdminNotifications />
       </div>
-      <OccupancyCalendar />
+      {isAuthenticated && <OccupancyCalendar />}
     </div>
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1968,7 +1968,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Calendar API - Get occupancy data for calendar visualization
-  app.get("/api/calendar/occupancy/:year/:month", async (req, res) => {
+  app.get("/api/calendar/occupancy/:year/:month", authenticateToken, async (req: any, res) => {
     try {
       const { year, month } = req.params;
       const yearInt = parseInt(year);


### PR DESCRIPTION
## Summary
- show occupancy calendar on dashboard only for authenticated users
- protect calendar API route with token authentication

## Testing
- `npm test` *(fails: Cannot find name 'test')*
- `npm run check` *(fails: TS1128 in settings_backup_broken.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689caa355e3483299d73c21529e90d6c