### PR TITLE
fix balance color when paid

### DIFF
--- a/client/src/components/daily-notifications.tsx
+++ b/client/src/components/daily-notifications.tsx
@@ -13,6 +13,7 @@ import { CheckoutConfirmationDialog } from "./confirmation-dialog";
 import type { Guest, PaginatedResponse } from "@shared/schema";
 import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { getGuestBalance, isGuestPaid } from "@/lib/guest";
 
 export default function DailyNotifications() {
   const labels = useAccommodationLabels();
@@ -207,11 +208,11 @@ export default function DailyNotifications() {
                         {guest.paymentAmount && (
                           <div className="flex items-center justify-between">
                             <span className="text-gray-600">Payment</span>
-                            <span className={`font-medium ${guest.isPaid ? '' : 'text-red-600'}`}>
+                            <span className={`font-medium ${isGuestPaid(guest) ? '' : 'text-red-600'}`}>
                               RM {guest.paymentAmount}
-                              {!guest.isPaid && guest.notes && (
+                              {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
                                 <span className="text-red-600 text-xs font-medium ml-1">
-                                  (Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'})
+                                  (Balance: RM{getGuestBalance(guest)})
                                 </span>
                               )}
                             </span>
@@ -295,11 +296,11 @@ export default function DailyNotifications() {
                         {guest.paymentAmount && (
                           <div className="flex items-center justify-between">
                             <span className="text-gray-600">Payment</span>
-                            <span className={`font-medium ${guest.isPaid ? '' : 'text-red-600'}`}>
+                            <span className={`font-medium ${isGuestPaid(guest) ? '' : 'text-red-600'}`}>
                               RM {guest.paymentAmount}
-                              {!guest.isPaid && guest.notes && (
+                              {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
                                 <span className="text-red-600 text-xs font-medium ml-1">
-                                  (Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'})
+                                  (Balance: RM{getGuestBalance(guest)})
                                 </span>
                               )}
                             </span>

--- a/client/src/components/guest-details-modal.tsx
+++ b/client/src/components/guest-details-modal.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { User, Calendar, MapPin, Phone, Mail, CreditCard, Edit, Save, X } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
+import { getGuestBalance, isGuestPaid } from "@/lib/guest";
 import { useToast } from "@/hooks/use-toast";
 import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 import type { Guest } from "@shared/schema";
@@ -104,6 +105,8 @@ export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetai
   };
 
   if (!guest) return null;
+  const balance = getGuestBalance(guest);
+  const paid = isGuestPaid(guest);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -154,10 +157,10 @@ export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetai
                 <span><span className="font-medium">Check‑in:</span> {formatDate(guest.checkinTime)}</span>
                 <span><span className="font-medium">Expected Checkout:</span> {guest.expectedCheckoutDate ? new Date(guest.expectedCheckoutDate.toString()).toLocaleDateString('en-US', {year:'numeric',month:'long',day:'numeric'}) : '—'}</span>
                 <span><span className="font-medium">Payment:</span> RM {guest.paymentAmount} • {guest.paymentMethod?.toUpperCase()}</span>
-                <span><span className="font-medium">Status:</span> {guest.isPaid ? 'Paid' : 'Outstanding'}</span>
-                {!guest.isPaid && guest.notes && (
+                <span><span className="font-medium">Status:</span> {paid ? 'Paid' : 'Outstanding'}</span>
+                {balance > 0 && (
                   <span className="text-red-600 font-medium">
-                    Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'}
+                    Balance: RM{balance}
                   </span>
                 )}
               </div>
@@ -385,11 +388,11 @@ export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetai
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
                 <Label>Amount</Label>
-                <div className={`mt-1 text-sm font-medium ${guest.isPaid ? '' : 'text-red-600'}`}>
+                <div className={`mt-1 text-sm font-medium ${paid ? '' : 'text-red-600'}`}>
                   RM {guest.paymentAmount}
-                  {!guest.isPaid && guest.notes && (
+                  {balance > 0 && (
                     <span className="text-red-600 text-xs font-medium ml-1">
-                      (Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'})
+                      (Balance: RM{balance})
                     </span>
                   )}
                 </div>
@@ -418,8 +421,8 @@ export default function GuestDetailsModal({ guest, isOpen, onClose }: GuestDetai
               <div>
                 <Label>Status</Label>
                 <div className="mt-1">
-                  <Badge variant={guest.isPaid ? "default" : "destructive"}>
-                    {guest.isPaid ? "Paid" : "Outstanding"}
+                  <Badge variant={paid ? "default" : "destructive"}>
+                    {paid ? "Paid" : "Outstanding"}
                   </Badge>
                 </div>
               </div>

--- a/client/src/components/guest-table/DesktopRow.tsx
+++ b/client/src/components/guest-table/DesktopRow.tsx
@@ -4,14 +4,15 @@ import { Button } from "@/components/ui/button";
 import { Copy } from "lucide-react";
 import type { Guest, GuestToken } from "@shared/schema";
 import { SwipeableGuestRow } from "./SwipeableGuestRow";
-import { 
-  getInitials, 
-  truncateName, 
-  getFirstInitial, 
-  getGenderIcon, 
-  formatShortDateTime, 
-  formatShortDate 
+import {
+  getInitials,
+  truncateName,
+  getFirstInitial,
+  getGenderIcon,
+  formatShortDateTime,
+  formatShortDate
 } from "./utils";
+import { getGuestBalance, isGuestPaid } from "@/lib/guest";
 
 interface RowData {
   items: Array<{ type: 'guest' | 'pending'; data: any }>;
@@ -99,11 +100,11 @@ export function DesktopRow({ index, style, data }: ListChildComponentProps<RowDa
                   <td className="px-2 py-3 whitespace-nowrap text-xs text-gray-600">
                     {guest.paymentAmount ? (
                       <div>
-                        <div className={`font-medium ${guest.isPaid ? '' : 'text-red-600'}`}>
+                        <div className={`font-medium ${isGuestPaid(guest) ? '' : 'text-red-600'}`}>
                           RM {guest.paymentAmount}
-                          {!guest.isPaid && guest.notes && (
+                          {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
                             <span className="text-red-600 text-xs font-medium ml-1">
-                              (Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'})
+                              (Balance: RM{getGuestBalance(guest)})
                             </span>
                           )}
                         </div>

--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -17,18 +17,19 @@ import type { Guest, GuestToken, PaginatedResponse } from "@shared/schema";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAccommodationLabels } from "@/hooks/useAccommodationLabels";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { 
-  getInitials, 
-  truncateName, 
-  getFirstInitial, 
-  getGenderIcon, 
-  formatShortDateTime, 
-  formatShortDate, 
-  ROW_HEIGHT 
+import {
+  getInitials,
+  truncateName,
+  getFirstInitial,
+  getGenderIcon,
+  formatShortDateTime,
+  formatShortDate,
+  ROW_HEIGHT
 } from "@/components/guest-table/utils";
 import { SortButton } from "@/components/guest-table/SortButton";
 import { SwipeableGuestRow } from "@/components/guest-table/SwipeableGuestRow";
 import { DesktopRow } from "@/components/guest-table/DesktopRow";
+import { getGuestBalance, isGuestPaid } from "@/lib/guest";
 
 type SortField = 'name' | 'capsuleNumber' | 'checkinTime' | 'expectedCheckoutDate';
 type SortOrder = 'asc' | 'desc';
@@ -478,11 +479,11 @@ export default function SortableGuestTable() {
                             <td className="px-2 py-3 whitespace-nowrap text-xs text-gray-600">
                               {guest.paymentAmount ? (
                                 <div>
-                                  <div className={`font-medium ${guest.isPaid ? '' : 'text-red-600'}`}>
+                                  <div className={`font-medium ${isGuestPaid(guest) ? '' : 'text-red-600'}`}>
                                     RM {guest.paymentAmount}
-                                    {!guest.isPaid && guest.notes && (
+                                    {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
                                       <span className="text-red-600 text-xs font-medium ml-1">
-                                        (Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'})
+                                        (Balance: RM{getGuestBalance(guest)})
                                       </span>
                                     )}
                                   </div>
@@ -670,12 +671,12 @@ export default function SortableGuestTable() {
                               </div>
                               <div className="col-span-2 flex flex-wrap items-center gap-2">
                                 <span className="font-medium text-gray-800">Payment:</span>
-                                <span className={guest.isPaid ? '' : 'text-red-600 font-semibold'}>RM {guest.paymentAmount}</span>
+                                <span className={isGuestPaid(guest) ? '' : 'text-red-600 font-semibold'}>RM {guest.paymentAmount}</span>
                                 {guest.paymentMethod && <span>• {guest.paymentMethod.toUpperCase()}</span>}
-                                <Badge variant={guest.isPaid ? 'default' : 'destructive'}>{guest.isPaid ? 'Paid' : 'Outstanding'}</Badge>
-                                {!guest.isPaid && guest.notes && (
+                                <Badge variant={isGuestPaid(guest) ? 'default' : 'destructive'}>{isGuestPaid(guest) ? 'Paid' : 'Outstanding'}</Badge>
+                                {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
                                   <span className="text-red-600 text-xs font-medium">
-                                    Balance: RM{guest.notes.match(/RM(\d+)/)?.[1] || '0'}
+                                    Balance: RM{getGuestBalance(guest)}
                                   </span>
                                 )}
                               </div>

--- a/client/src/lib/guest.ts
+++ b/client/src/lib/guest.ts
@@ -1,0 +1,10 @@
+import type { Guest } from "@shared/schema";
+
+export function getGuestBalance(guest: Guest): number {
+  const match = guest.notes?.match(/RM(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+export function isGuestPaid(guest: Guest): boolean {
+  return guest.isPaid || getGuestBalance(guest) <= 0;
+}

--- a/client/src/pages/check-out.tsx
+++ b/client/src/pages/check-out.tsx
@@ -15,6 +15,7 @@ import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 import type { Guest, PaginatedResponse } from "@shared/schema";
+import { isGuestPaid } from "@/lib/guest";
 
 function formatDuration(checkinTime: string): string {
   const checkin = new Date(checkinTime);
@@ -321,8 +322,8 @@ export default function CheckOut() {
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap">
                                 <div className="flex items-center gap-2">
-                                  <div className={`w-2 h-2 ${guest.isPaid ? 'bg-green-500' : 'bg-red-500'} rounded-full`}></div>
-                                  <span className="text-xs text-gray-600">{guest.isPaid ? 'Paid' : 'Unpaid'}</span>
+                                  <div className={`w-2 h-2 ${isGuestPaid(guest) ? 'bg-green-500' : 'bg-red-500'} rounded-full`}></div>
+                                  <span className="text-xs text-gray-600">{isGuestPaid(guest) ? 'Paid' : 'Unpaid'}</span>
                                 </div>
                               </td>
                             </>


### PR DESCRIPTION
## Summary
- parse balance from notes to determine paid status
- show red balance only when outstanding across guest views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5447ed788329821ca1bc83b2942e