### PR TITLE
Remove redundant details icon on dashboard

### DIFF
--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -834,19 +834,8 @@ export default function SortableGuestTable() {
                         </div>
                       </div>
                       <div className="flex items-center gap-2">
-                        <div className="h-11 w-11 rounded-full flex items-center justify-center text-gray-400 text-xs">
-                          —
-                        </div>
-                        <Button 
-                          variant="ghost" 
-                          className="h-11 w-11 rounded-full"
-                          onClick={() => handleGuestClick(guest)}
-                          title="Details"
-                        >
-                          i
-                        </Button>
-                        <Button 
-                          variant="destructive" 
+                        <Button
+                          variant="destructive"
                           className="h-11 w-11 rounded-full"
                           onClick={() => handleCheckout(guest.id)}
                           disabled={isGuestCheckingOut}


### PR DESCRIPTION
## Summary
- remove unused guest details icon from dashboard guest list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea7f004dc83299cf5f1bf3ba4d0a0