### PR TITLE
feat: add phone call button on mobile dashboard

### DIFF
--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { UserMinus, ArrowUpDown, ArrowUp, ArrowDown, ToggleLeft, ToggleRight, ChevronLeft, Copy, Filter as FilterIcon, CalendarPlus } from "lucide-react";
+import { UserMinus, ArrowUpDown, ArrowUp, ArrowDown, ToggleLeft, ToggleRight, ChevronLeft, Copy, Filter as FilterIcon, CalendarPlus, Phone } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Label } from "@/components/ui/label";
@@ -839,6 +839,18 @@ export default function SortableGuestTable() {
                         )}
                       </div>
                       <div className="flex items-center gap-2">
+                        {guest.phoneNumber && (
+                          <Button
+                            variant="secondary"
+                            className="h-11 w-11 rounded-full"
+                            asChild
+                            title={`Call ${guest.phoneNumber}`}
+                          >
+                            <a href={`tel:${guest.phoneNumber}`}>
+                              <Phone className="h-4 w-4" />
+                            </a>
+                          </Button>
+                        )}
                         <Button
                           variant="destructive"
                           className="h-11 w-11 rounded-full"


### PR DESCRIPTION
## Summary
- show phone icon beside checkout on mobile guest cards when a phone number exists
- tap the icon to initiate a call to the guest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee74f06e483298d3ec73b9ca7aa7a