### PR TITLE
Center document upload modal

### DIFF
--- a/client/src/components/ObjectUploader.tsx
+++ b/client/src/components/ObjectUploader.tsx
@@ -77,6 +77,11 @@ export function ObjectUploader({
         allowedFileTypes,
       },
       autoProceed: true,
+      locale: {
+        strings: {
+          dropPasteFiles: '📁 Drop files here or %{browseFiles}',
+        },
+      },
     })
       .use(AwsS3, {
         shouldUseMultipart: false,
@@ -135,6 +140,7 @@ export function ObjectUploader({
         open={showModal}
         onRequestClose={() => setShowModal(false)}
         proudlyDisplayPoweredByUppy={false}
+        note="📷 Upload a clear photo of your document"
       />
     </div>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -236,7 +236,7 @@
 }
 
   /* Print styles for check-in slip */
-  @media print {
+@media print {
     /* Hide everything except the check-in slip */
     body * {
       visibility: hidden;
@@ -298,5 +298,16 @@
     /* Remove edit section in print */
     .bg-yellow-50 {
       display: none !important;
-    }
   }
+}
+
+@layer components {
+  /* Center Uppy dashboard modal on screen */
+  .uppy-Dashboard--modal .uppy-Dashboard-inner {
+    top: 50% !important;
+    left: 50% !important;
+    right: auto !important;
+    bottom: auto !important;
+    transform: translate(-50%, -50%) !important;
+  }
+}


### PR DESCRIPTION
## Summary
- center the Uppy document upload modal so it appears in the middle of the screen
- add icons and descriptive note to the upload modal for a more polished experience

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5b9921e8832989d6572fb765da2e