### PR TITLE
Remove mobile dashboard initial avatars

### DIFF
--- a/client/src/components/sortable-guest-table.tsx
+++ b/client/src/components/sortable-guest-table.tsx
@@ -786,7 +786,6 @@ export default function SortableGuestTable() {
               if (item.type === 'guest') {
                 const guest = item.data as Guest;
                 const isGuestCheckingOut = checkoutGuest?.id === guest.id;
-                const genderIcon = getGenderIcon(guest.gender || undefined);
                 return (
                   <Card key={`guest-${guest.id}`} className="p-0 overflow-hidden hover-card-pop">
                     <SwipeableGuestCard
@@ -796,50 +795,45 @@ export default function SortableGuestTable() {
                       isCheckingOut={isGuestCheckingOut}
                     >
                     <div className="p-3 flex items-center justify-between gap-3">
-                      <div className="flex items-center gap-3">
-                        <div className={`w-10 h-10 ${genderIcon.bgColor} rounded-full flex items-center justify-center text-sm font-semibold ${genderIcon.textColor}`}>
-                          {getFirstInitial(guest.name)}
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="bg-blue-600 text-white border-blue-600">{guest.capsuleNumber}</Badge>
+                          <button onClick={() => handleGuestClick(guest)} className="font-medium hover:underline focus:outline-none">
+                            {guest.name}
+                          </button>
                         </div>
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline" className="bg-blue-600 text-white border-blue-600">{guest.capsuleNumber}</Badge>
-                            <button onClick={() => handleGuestClick(guest)} className="font-medium hover:underline focus:outline-none">
-                              {guest.name}
-                            </button>
-                          </div>
-                          <div className="text-xs text-gray-600 mt-1">
-                            In: {formatShortDateTime(guest.checkinTime.toString())}
-                            {guest.expectedCheckoutDate && (
-                              <span className="ml-2">Out: {formatShortDate(guest.expectedCheckoutDate)}</span>
-                            )}
-                          </div>
-                          {!isCondensedView && (
-                            <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-gray-700">
-                              <div>
-                                <span className="font-medium text-gray-800">Nationality:</span> {guest.nationality || '—'}
-                              </div>
-                              <div>
-                                <span className="font-medium text-gray-800">Phone:</span> {guest.phoneNumber || '—'}
-                              </div>
-                              <div className="col-span-2 flex flex-wrap items-center gap-2">
-                                <span className="font-medium text-gray-800">Payment:</span>
-                                <span className={isGuestPaid(guest) ? '' : 'text-red-600 font-semibold'}>RM {guest.paymentAmount}</span>
-                                {guest.paymentMethod && <span>• {guest.paymentMethod.toUpperCase()}</span>}
-                                <Badge variant={isGuestPaid(guest) ? 'default' : 'destructive'}>{isGuestPaid(guest) ? 'Paid' : 'Outstanding'}</Badge>
-                                {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
-                                  <span className="text-red-600 text-xs font-medium">
-                                    Balance: RM{getGuestBalance(guest)}
-                                  </span>
-                                )}
-                              </div>
-                              {guest.paymentCollector && (
-                                <div className="col-span-2">
-                                  <span className="font-medium text-gray-800">Collected by:</span> {guest.paymentCollector}
-                                </div>
-                              )}
-                            </div>
+                        <div className="text-xs text-gray-600 mt-1">
+                          In: {formatShortDateTime(guest.checkinTime.toString())}
+                          {guest.expectedCheckoutDate && (
+                            <span className="ml-2">Out: {formatShortDate(guest.expectedCheckoutDate)}</span>
                           )}
                         </div>
+                        {!isCondensedView && (
+                          <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-gray-700">
+                            <div>
+                              <span className="font-medium text-gray-800">Nationality:</span> {guest.nationality || '—'}
+                            </div>
+                            <div>
+                              <span className="font-medium text-gray-800">Phone:</span> {guest.phoneNumber || '—'}
+                            </div>
+                            <div className="col-span-2 flex flex-wrap items-center gap-2">
+                              <span className="font-medium text-gray-800">Payment:</span>
+                              <span className={isGuestPaid(guest) ? '' : 'text-red-600 font-semibold'}>RM {guest.paymentAmount}</span>
+                              {guest.paymentMethod && <span>• {guest.paymentMethod.toUpperCase()}</span>}
+                              <Badge variant={isGuestPaid(guest) ? 'default' : 'destructive'}>{isGuestPaid(guest) ? 'Paid' : 'Outstanding'}</Badge>
+                              {!isGuestPaid(guest) && getGuestBalance(guest) > 0 && (
+                                <span className="text-red-600 text-xs font-medium">
+                                  Balance: RM{getGuestBalance(guest)}
+                                </span>
+                              )}
+                            </div>
+                            {guest.paymentCollector && (
+                              <div className="col-span-2">
+                                <span className="font-medium text-gray-800">Collected by:</span> {guest.paymentCollector}
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         <Button
@@ -861,35 +855,30 @@ export default function SortableGuestTable() {
                 return (
                   <Card key={`pending-${pendingData.id}`} className="p-3 bg-orange-50/60 hover-card-pop">
                     <div className="flex items-center justify-between gap-3">
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-orange-100 rounded-full flex items-center justify-center text-sm font-semibold text-orange-600">
-                          P
+                      <div>
+                        <button
+                          onClick={() => handlePendingCheckinClick(pendingData.id)}
+                          className="flex items-center gap-2 focus:outline-none"
+                        >
+                          <Badge variant="outline" className="bg-orange-500 text-white border-orange-500">{pendingData.capsuleNumber}</Badge>
+                          <span className="font-medium cursor-pointer underline-offset-2 hover:underline">{pendingData.name}</span>
+                        </button>
+                        <div className="text-xs text-orange-700 mt-1">
+                          In: {formatShortDateTime(pendingData.createdAt)}
+                          <span className="ml-2">Expires: {formatShortDate(pendingData.expiresAt)}</span>
                         </div>
-                        <div>
-                          <button
-                            onClick={() => handlePendingCheckinClick(pendingData.id)}
-                            className="flex items-center gap-2 focus:outline-none"
-                          >
-                            <Badge variant="outline" className="bg-orange-500 text-white border-orange-500">{pendingData.capsuleNumber}</Badge>
-                            <span className="font-medium cursor-pointer underline-offset-2 hover:underline">{pendingData.name}</span>
-                          </button>
-                          <div className="text-xs text-orange-700 mt-1">
-                            In: {formatShortDateTime(pendingData.createdAt)}
-                            <span className="ml-2">Expires: {formatShortDate(pendingData.expiresAt)}</span>
-                          </div>
-                          {!isCondensedView && (
-                            <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-orange-700">
-                              <div className="col-span-2">
-                                <span className="font-medium">Status:</span> Awaiting self check-in
-                              </div>
-                              {pendingData.phoneNumber && (
-                                <div className="col-span-2">
-                                  <span className="font-medium">Phone:</span> {pendingData.phoneNumber}
-                                </div>
-                              )}
+                        {!isCondensedView && (
+                          <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-orange-700">
+                            <div className="col-span-2">
+                              <span className="font-medium">Status:</span> Awaiting self check-in
                             </div>
-                          )}
-                        </div>
+                            {pendingData.phoneNumber && (
+                              <div className="col-span-2">
+                                <span className="font-medium">Phone:</span> {pendingData.phoneNumber}
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         {isAuthenticated ? (


### PR DESCRIPTION
## Summary
- Remove round initial icons from mobile guest cards to free up space
- Remove pending check-in avatar circles in mobile dashboard view

## Testing
- `npm test`
- `npm run check` *(fails: server TypeScript errors in storage.ts and validation.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689ee5ed6d9c832993dcc38905c10295