### PR TITLE
Fix self check-in photo upload using object storage

### DIFF
--- a/client/src/pages/check-in.tsx
+++ b/client/src/pages/check-in.tsx
@@ -38,8 +38,7 @@ import CheckInDetailsSection from "@/components/check-in/CheckInDetailsSection";
 import SmartFeaturesSection from "@/components/check-in/SmartFeaturesSection";
 import StepProgressIndicator from "@/components/check-in/StepProgressIndicator";
 
-import { SmartPhotoUploader } from "@/components/SmartPhotoUploader";
-import { Camera, Upload } from "lucide-react";
+// Removed SmartPhotoUploader in favor of ObjectUploader in IdentificationPersonalSection
 
 export default function CheckIn() {
   const labels = useAccommodationLabels();


### PR DESCRIPTION
## Summary
- replace SmartPhotoUploader in admin self check-in with ObjectUploader
- handle presigned URL retrieval and result parsing to save uploaded document URL
- remove unused SmartPhotoUploader import on check-in page

## Testing
- `npm test`
- `npm run check` *(fails: server/storage.ts type issues)*

------
https://chatgpt.com/codex/tasks/task_e_689f6bbdaea48329b63f1d12ff18cecf