### PR TITLE
fix calendar month indexing to API

### DIFF
--- a/client/src/components/occupancy-calendar.tsx
+++ b/client/src/components/occupancy-calendar.tsx
@@ -43,7 +43,12 @@ export default function OccupancyCalendar() {
 
   // Fetch calendar data for the current month
   const { data: calendarData = {}, isLoading: isCalendarLoading } = useVisibilityQuery<CalendarData>({
-    queryKey: ["/api/calendar/occupancy", currentMonth.getFullYear(), currentMonth.getMonth()],
+    // Date.getMonth() is zero-indexed, but the API expects months 1-12
+    queryKey: [
+      "/api/calendar/occupancy",
+      currentMonth.getFullYear(),
+      currentMonth.getMonth() + 1,
+    ],
     enabled: isCalendarVisible,
     // Uses smart config: nearRealtime (30s stale, 60s refetch) for calendar data
   });


### PR DESCRIPTION
## Summary
- fix occupancy calendar month parameter to send 1-12 to server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a55a3290b88329aeb2c3ed4472d058